### PR TITLE
URL Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 before_install:
 - gem install sass
 - npm install -g bower
-- wget http://repo.spring.io/release/org/springframework/boot/spring-boot-cli/1.4.6.RELEASE/spring-boot-cli-1.4.6.RELEASE-bin.tar.gz
+- wget https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/1.4.6.RELEASE/spring-boot-cli-1.4.6.RELEASE-bin.tar.gz
 - tar xvfz spring-boot-cli-1.4.6.RELEASE-bin.tar.gz
 - export PATH=$PATH:spring-1.4.6.RELEASE/bin
 - spring --version

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Travis Aggregator [![Build Status](https://travis-ci.org/spring-guides/drone-aggregator.svg?branch=master)](https://travis-ci.org/spring-guides/drone-aggregator)
 
-Running more than a handful of CI jobs at http://travis-ci.org? Their usage of screen real estate can leave you scrolling all the time when you really need a quick glance to see if everything is up.
+Running more than a handful of CI jobs at https://travis-ci.org? Their usage of screen real estate can leave you scrolling all the time when you really need a quick glance to see if everything is up.
 
-travis-aggregator is a [Spring Boot](http://projects.spring.io/spring-boot/) application that uses [Jsoup](http://jsoup.org) to elegantly grab every [Getting Started Guide](http://spring.io/guides) and construct a slim and trim table with links to each guide as well as its corresponding Travis CI job.
+travis-aggregator is a [Spring Boot](https://projects.spring.io/spring-boot/) application that uses [Jsoup](https://jsoup.org) to elegantly grab every [Getting Started Guide](https://spring.io/guides) and construct a slim and trim table with links to each guide as well as its corresponding Travis CI job.
 
-> **NOTE:** See http://bit.ly/app-mgmt-tools-with-boot for a webinar that walks through this app.
+> **NOTE:** See https://bit.ly/app-mgmt-tools-with-boot for a webinar that walks through this app.
 
-[![Webinar showing this app](http://i.ytimg.com/vi/j3rrqOV68ik/mqdefault.jpg)](http://bit.ly/app-mgmt-tools-with-boot)
+[![Webinar showing this app](https://i.ytimg.com/vi/j3rrqOV68ik/mqdefault.jpg)](https://bit.ly/app-mgmt-tools-with-boot)
 
 ## Getting Started
 
-You first need to [install Spring Boot](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#getting-started-installing-the-cli). I won't show that here because the instructions behind that link are pretty detailed. I'll just assume you got things set up right.
+You first need to [install Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#getting-started-installing-the-cli). I won't show that here because the instructions behind that link are pretty detailed. I'll just assume you got things set up right.
 
 ## Run the application
 Now you can run the application.

--- a/app.groovy
+++ b/app.groovy
@@ -36,13 +36,13 @@ class ConcourseAggregator {
     @Value('${org:spring-guides}')
     String org
 
-    @Value('${site:http://spring.io}')
+    @Value('${site:https://spring.io}')
     String site
 
     @Value('${css.selector:a.guide--title}')
     String cssSelector
 
-    @Value('${issue.site:http://issue-aggregator.guides.spring.io/}')
+    @Value('${issue.site:https://issue-aggregator.guides.spring.io/}')
     String issueSite
 
     @Autowired

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head>
-    <link href='http://fonts.googleapis.com/css?family=Ubuntu' rel='stylesheet' type='text/css'/>
+    <link href='https://fonts.googleapis.com/css?family=Ubuntu' rel='stylesheet' type='text/css'/>
     <title>Travis Aggregator</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0" />


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://issue-aggregator.guides.spring.io/ (ReadTimeoutException) with 1 occurrences migrated to:  
  https://issue-aggregator.guides.spring.io/ ([https](https://issue-aggregator.guides.spring.io/) result SSLHandshakeException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://fonts.googleapis.com/css?family=Ubuntu with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Ubuntu ([https](https://fonts.googleapis.com/css?family=Ubuntu) result 200).
* [ ] http://i.ytimg.com/vi/j3rrqOV68ik/mqdefault.jpg with 1 occurrences migrated to:  
  https://i.ytimg.com/vi/j3rrqOV68ik/mqdefault.jpg ([https](https://i.ytimg.com/vi/j3rrqOV68ik/mqdefault.jpg) result 200).
* [ ] http://jsoup.org with 1 occurrences migrated to:  
  https://jsoup.org ([https](https://jsoup.org) result 200).
* [ ] http://projects.spring.io/spring-boot/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot/ ([https](https://projects.spring.io/spring-boot/) result 200).
* [ ] http://repo.spring.io/release/org/springframework/boot/spring-boot-cli/1.4.6.RELEASE/spring-boot-cli-1.4.6.RELEASE-bin.tar.gz with 1 occurrences migrated to:  
  https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/1.4.6.RELEASE/spring-boot-cli-1.4.6.RELEASE-bin.tar.gz ([https](https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/1.4.6.RELEASE/spring-boot-cli-1.4.6.RELEASE-bin.tar.gz) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://travis-ci.org with 1 occurrences migrated to:  
  https://travis-ci.org ([https](https://travis-ci.org) result 200).
* [ ] http://www.thymeleaf.org with 1 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://bit.ly/app-mgmt-tools-with-boot with 2 occurrences migrated to:  
  https://bit.ly/app-mgmt-tools-with-boot ([https](https://bit.ly/app-mgmt-tools-with-boot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences